### PR TITLE
Add option to use code-server startup Variables

### DIFF
--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -50,4 +50,4 @@ fi
 # --config '/config/code-server/config/config.yml' = filepath to config file (contains password amongst other things)
 # --user-data-dir '/config/code-server/user-data' = define path to store user data
 # --extensions-dir '/config/code-server/extensions' = define path to store extensions
-/usr/bin/code-server --disable-telemetry --disable-update-check --bind-addr 0.0.0.0:8500 ${link} ${cert} ${cert_key} --config '/config/code-server/config/config.yml' --user-data-dir '/config/code-server/user-data' --extensions-dir '/config/code-server/extensions' ${code_startup}
+/usr/bin/code-server --disable-telemetry --disable-update-check --bind-addr 0.0.0.0:8500 ${link} ${cert} ${cert_key} --config '/config/code-server/config/config.yml' --user-data-dir '/config/code-server/user-data' --extensions-dir '/config/code-server/extensions' ${CODE_STARTUP}

--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -50,4 +50,4 @@ fi
 # --config '/config/code-server/config/config.yml' = filepath to config file (contains password amongst other things)
 # --user-data-dir '/config/code-server/user-data' = define path to store user data
 # --extensions-dir '/config/code-server/extensions' = define path to store extensions
-/usr/bin/code-server --disable-telemetry --disable-update-check --bind-addr 0.0.0.0:8500 ${link} ${cert} ${cert_key} --config '/config/code-server/config/config.yml' --user-data-dir '/config/code-server/user-data' --extensions-dir '/config/code-server/extensions'
+/usr/bin/code-server --disable-telemetry --disable-update-check --bind-addr 0.0.0.0:8500 ${link} ${cert} ${cert_key} --config '/config/code-server/config/config.yml' --user-data-dir '/config/code-server/user-data' --extensions-dir '/config/code-server/extensions' ${code_startup}


### PR DESCRIPTION
tbh didn't really test it, but i need the option to add startup variables to the code server to use a proxy(I don't want to proxy everything and in default mode code-server doesn't use the no_proxy env var). This should be possible by using the following addition